### PR TITLE
fixes single wsl distro issue

### DIFF
--- a/PSWsl.psm1
+++ b/PSWsl.psm1
@@ -179,9 +179,9 @@ function Get-WslDistribution {
             '( ' + ( $DistributionName.ForEach( { "`$_.DistributionName   -like `"$_`"" } ) -join ' -or ' ) + ' )') )
         
         if ($Default) {
-            return $distributionArray.Where( { $_.Default } )
+            return @($distributionArray).Where( { $_.Default } )
         } else {
-            return $distributionArray.Where( $Filter )
+            return @($distributionArray).Where( $Filter )
         }
     }
     


### PR DESCRIPTION
If the user only has 1 WSL distro, then the foreach just returns the single item instead of an array. This was throwing an error